### PR TITLE
feat: Especificando o id de subscriber para homologação

### DIFF
--- a/docs/pt-br/resultado_covid.md
+++ b/docs/pt-br/resultado_covid.md
@@ -98,7 +98,7 @@ Como a mensagem possui um tempo para expirar, caso seja necessário uma maior qu
 Configurações:
 
 - identificador do projeto: `api-mendelics-dev`
-- identificador do subscriber: o mesmo que para produção
+- identificador do subscriber: `homolog-result-sub`
 - tópico: `homolog-result`
 
 ### Ambiente de produção


### PR DESCRIPTION
Alterando uma linha na documentação para especificar o ID de subscriber de desenvolvimento novo.