### PR TITLE
feat: adicionando informações sobre os campos novos

### DIFF
--- a/docs/pt-br/resultado_covid.md
+++ b/docs/pt-br/resultado_covid.md
@@ -24,7 +24,9 @@ As mensagens contêm o seguinte dado estruturado em formato JSON.
 {
   "sample_code": "CODIGO",
   "type": "TIPO_DE_TESTE",
-  "result": "RESULTADO_TESTE"
+  "result": "RESULTADO_TESTE",
+  "name": "NOME_PACIENTE",
+  "birth_date": "DATA_NASCIMENTO_PACIENTE"
 }
 ```
 
@@ -36,6 +38,8 @@ A seguir apresentamos o valor de cada campo.
   - `positive` (caso positivo)
   - `negative` (caso negativo)
   - `non_compliance` (recusa do exame pela triagem por problema com a amostra).
+- `name`: O nome do paciente do exame.
+- `birth_date`: A data de nascimento do paciente do exame.
 
 ### Garantia de envio de mensagem
 

--- a/docs/pt-br/resultado_covid.md
+++ b/docs/pt-br/resultado_covid.md
@@ -39,7 +39,7 @@ A seguir apresentamos o valor de cada campo.
   - `negative` (caso negativo)
   - `non_compliance` (recusa do exame pela triagem por problema com a amostra).
 - `name`: O nome do paciente do exame.
-- `birth_date`: A data de nascimento do paciente do exame.
+- `birth_date`: A data de nascimento do paciente do exame, no formato `yyyy-mm-dd`.
 
 ### Garantia de envio de mensagem
 


### PR DESCRIPTION
[Card do problema](https://trello.com/c/Q7Ccldh7/558-adicionar-campos-name-e-birthdate-no-retorno-de-resultados-covid-para-graded)


Este PR adiciona o detalhamento das informações incluídas recentemente no retorno da homologação da graded. Os campos são `name` e `birth_date` que guardam o nome e a data de nascimento do paciente do exame.